### PR TITLE
Added support for custom rpm macros by 'defining rpm_macro_map'

### DIFF
--- a/src/main/groovy/org/fhw/gradle/simplerpm/BaseTask.groovy
+++ b/src/main/groovy/org/fhw/gradle/simplerpm/BaseTask.groovy
@@ -37,5 +37,11 @@ class BaseTask extends DefaultTask {
         }       
         return( process.waitFor() == 0)                 
     }    
-    
+
+    def getRpmbbuildMacroArgs() {
+        def rpm_macro_map = project.simplerpm.rpm_macro_map
+        if (!rpm_macro_map) { return [] }
+        rpm_macro_map.collectMany { ['--define', "${it.key} ${it.value}"] }
+    }
+
 }

--- a/src/main/groovy/org/fhw/gradle/simplerpm/MakeRPMTask.groovy
+++ b/src/main/groovy/org/fhw/gradle/simplerpm/MakeRPMTask.groovy
@@ -31,16 +31,19 @@ class MakeRPMTask extends BaseTask {
         src = Paths.get(getSpecFilePath())
         Files.copy(src,targ_spec_dir.resolve(src.getFileName()),StandardCopyOption.REPLACE_EXISTING)
         
-        if(!execute(    'rpmbuild',
-                        '--define', 
-                        "_topdir ${project.buildDir}/tmp",
-                        '--define',
-                        "VERSION ${project.version}",
-                        '--define',
-                        "_tmppath  %{_topdir}/tmp",
-                        '-bb',
-                        "${targ_spec_dir}/${src.fileName}")) {
-            
+        def cmd = [ 'rpmbuild',
+            '--define',
+            "_topdir ${project.buildDir}/tmp",
+            '--define',
+            "VERSION ${project.version}",
+            '--define',
+            "_tmppath  %{_topdir}/tmp",
+            getRpmbbuildMacroArgs(),
+            '-bb',
+            "${targ_spec_dir}/${src.fileName}"
+        ].flatten()
+
+        if(!execute(*cmd)) {
             throw new TaskExecutionException(this,new Exception('rpmbuild failed'))
         }
     }

--- a/src/main/groovy/org/fhw/gradle/simplerpm/SimpleRPMPluginExtension.groovy
+++ b/src/main/groovy/org/fhw/gradle/simplerpm/SimpleRPMPluginExtension.groovy
@@ -3,5 +3,5 @@ package org.fhw.gradle.simplerpm
 class SimpleRPMPluginExtension {
     def String artifact_to_include
     def String spec_file
+    def Map rpm_macro_map
 }
-   

--- a/src/test/groovy/org/fhw/gradle/simplerpm/BaseTaskSpec.groovy
+++ b/src/test/groovy/org/fhw/gradle/simplerpm/BaseTaskSpec.groovy
@@ -60,6 +60,34 @@ class BaseTaskSpec extends Specification {
         then:  
             ! art
     }    
-    
+
+    def "Test get rpm build macro args"() {
+        given:
+            Project project = ProjectBuilder.builder().build()
+            project.apply plugin: 'simplerpm'
+            project.simplerpm.rpm_macro_map = [ 'foo': 'bar', 'moo': 'cow']
+
+        when:
+            List args = project.tasks.rpm.getRpmbbuildMacroArgs()
+
+        then:
+        args == [
+          '--define', 'foo bar',
+          '--define', 'moo cow'
+        ]
+    }
+
+    def "Test get rpm build macro args default case"() {
+        given:
+            Project project = ProjectBuilder.builder().build()
+            project.apply plugin: 'simplerpm'
+
+        when:
+            List args = project.tasks.rpm.getRpmbbuildMacroArgs()
+
+        then:
+        args == []
+    }
+
 }
 


### PR DESCRIPTION
Added support for custom rpm macros:

build.gradle:

``` gradle
simplerpm {
  spec_file = 'some.spec'
  rpm_macro_map = ['foo': 'bar']
}
```

some.spec:

``` spec
Name: %{foo}
```
